### PR TITLE
Fix cursor accessibility for touch and reduced-motion users

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -87,8 +87,18 @@ const { title, description = siteConfig.profile.identityLine } = Astro.props;
 					observer.observe(element);
 				});
 
+				const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+				const hasFinePointer = window.matchMedia('(pointer: fine)').matches;
+
+				// Custom cursor should only run for mouse/trackpad users who don't request reduced motion.
+				if (!hasFinePointer || prefersReducedMotion) {
+					document.documentElement.classList.add('native-cursor');
+					return;
+				}
+
 				// Custom Cursor & Ambient Glow Logic Custom Physics Loop
 				if(!window.cursorInitialized) {
+					document.documentElement.classList.remove('native-cursor');
 					const dot = document.getElementById('cursor-dot');
 					const ring = document.getElementById('cursor-ring');
 					const ambientGlow = document.getElementById('ambient-glow');
@@ -173,8 +183,8 @@ const { title, description = siteConfig.profile.identityLine } = Astro.props;
 </html>
 
 <style is:global>
-	/* Hide native cursor globally to replace with custom one */
-	* {
+	/* Hide native cursor globally when custom cursor is enabled */
+	html:not(.native-cursor) * {
 		cursor: none !important;
 	}
 


### PR DESCRIPTION
### Motivation
- The site globally hid the native cursor (`cursor: none`) which could break usability for touch/coarse-pointer devices and for users who prefer reduced motion.
- Improve accessibility by enabling the custom cursor only for appropriate input modalities and motion preferences.

### Description
- Added runtime capability checks in `src/layouts/Layout.astro` to detect `(pointer: fine)` and `prefers-reduced-motion` and early-return to a fallback when needed.
- Introduced a `native-cursor` HTML class that is applied when the custom cursor is disabled to preserve the system cursor.
- Scoped the global cursor-hiding CSS to `html:not(.native-cursor) * { cursor: none !important; }` so the native cursor is only hidden when the custom cursor is active.
- Kept the custom cursor initialization and ambient-glow logic intact but gated it behind the new checks so only eligible clients run the effect.

### Testing
- Ran `npm run build` and the static site built successfully (all pages generated).
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4321` and verified the site started and served pages.
- Executed a Playwright script to capture a homepage screenshot which completed and produced an artifact for visual inspection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab0cc6753c832b9ce34c779dae2690)