### PR TITLE
Add REVIEW.md: repository technical review and recommendations

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,27 @@
+# Repository Review
+
+## Scope
+Quick technical review of the Astro portfolio repository, focused on build health, configuration clarity, and content quality.
+
+## What was checked
+- Dependency install with lockfile.
+- Production build generation.
+- Key content/config files (`README.md`, `src/content/site.ts`, and page/component structure).
+
+## Findings
+### ✅ Strengths
+1. The project builds successfully and generates static pages for all declared routes.
+2. Content is centralized in `src/content/site.ts`, which keeps updates straightforward.
+3. The architecture is clean and conventional for Astro (`components`, `layouts`, `pages`, `content`).
+
+### ⚠️ Observations
+1. Build logs include a non-blocking line: `✘ [ERROR] The build was canceled`, but the build exits successfully and all pages are produced. This appears to be transient tooling noise, not a functional failure.
+2. `COMPLETION_REPORT.md` appears historical and references a local Windows path from an earlier setup process; treat it as archival rather than operational documentation.
+
+## Recommended next improvements
+1. Add a lightweight CI workflow (e.g., GitHub Actions) that runs `npm ci` and `npm run build` on pushes/PRs.
+2. Consider adding a content validation script for `src/content/site.ts` (e.g., verifying all project links/files exist).
+3. Keep operational docs in `README.md`, and either remove or rename historical reports to reduce confusion.
+
+## Review outcome
+The repository is in good working condition and ready for incremental polish and automation improvements.


### PR DESCRIPTION
### Motivation
- Provide a concise, shareable technical review that documents build health, content centralization, and actionable next steps for CI and content validation.

### Description
- Add `REVIEW.md` containing the review scope, checks performed, findings (strengths and observations), and recommended improvements; this change is documentation-only and does not modify runtime code.

### Testing
- Ran `npm ci` and `npm run build`, and both completed successfully while producing the static routes for the site (build log included a non-blocking tooling message that did not prevent output).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab0cc6753c832b9ce34c779dae2690)